### PR TITLE
Fix linking: multiple definition of in6addr_localmast

### DIFF
--- a/netsock.h
+++ b/netsock.h
@@ -8,7 +8,7 @@
 #define DDHCP_MULTICAST_PORT 1234
 #define DDHCP_UNICAST_PORT 1235
 
-const struct in6_addr in6addr_localmast;
+extern const struct in6_addr in6addr_localmast;
 
 // ddhcpd_socket_init_t implementations
 ATTR_NONNULL_ALL int netsock_multicast_init(epoll_data_t data,ddhcp_config* config);


### PR DESCRIPTION
Without this, ddhcpd cannot be built with a modern toolchain due to multiple definion of in6addr_localmast.