### PR TITLE
feat: add claim hook that "warms up" free addresses

### DIFF
--- a/dhcp.c
+++ b/dhcp.c
@@ -572,6 +572,7 @@ ATTR_NONNULL_ALL int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lea
   lease->xid = request->xid;
   lease->state = LEASED;
   lease->lease_end = now + find_in_option_store_address_lease_time(&config->options)  + DHCP_LEASE_SERVER_DELTA;
+  lease->hookclaim = 0; // take it over, without unclaiming it
 
   addr_add(&lease_block->subnet, &packet->yiaddr, (int)lease_index);
 

--- a/example-hook.sh
+++ b/example-hook.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 
 case $1 in
-  lease)
+  lease) # when a lease happens
     echo $@ >> /tmp/hook.log
     ;;
-  release)
+  release) # when a client requests a release or a lease expires
     echo $@ >> /tmp/hook.log
     ;;
-  endlearning)
+  endlearning) # once the initial timeout for gathering all blocks ends
     echo "$@ - learning phase is over" >> /tmp/hook.log
+    ;;
+  # if you want to propagate addresses in some way in the network, those two hooks can be used for that
+  claim) # after ddhcpd has claimed this particular address - you can also use lease|claim)
+    echo $@ >> /tmp/hook.log
+    ;;
+  claimrelease) # before this block is no logner claimed - you can also use release|claimrelease)
+    echo $@ >> /tmp/hook.log
     ;;
 esac

--- a/hook.c
+++ b/hook.c
@@ -3,7 +3,6 @@
 #include "tools.h"
 
 #include <unistd.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 
 ATTR_NONNULL_ALL void hook_address(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config) {
@@ -33,6 +32,14 @@ ATTR_NONNULL_ALL void hook_address(uint8_t type, struct in_addr* address, uint8_
 
   case HOOK_INFORM:
     action = (char*)"inform";
+    break;
+
+  case HOOK_CLAIM:
+    action = (char*)"claim";
+    break;
+
+  case HOOK_CLAIM_RELEASE:
+    action = (char*)"claimrelease";
     break;
 
   default:

--- a/hook.h
+++ b/hook.h
@@ -7,6 +7,8 @@
 #define HOOK_RELEASE 2
 #define HOOK_INFORM 3
 #define HOOK_LEARNING_PHASE_END 4
+#define HOOK_CLAIM 5
+#define HOOK_CLAIM_RELEASE 6
 
 ATTR_NONNULL_ALL void hook_address(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config);
 ATTR_NONNULL_ALL void hook(uint8_t type, ddhcp_config* config);

--- a/tools.c
+++ b/tools.c
@@ -91,3 +91,17 @@ ATTR_NONNULL_ALL char* hwaddr2c(uint8_t* hwaddr) {
 
   return str;
 }
+
+ATTR_NONNULL_ALL uint8_t * nodeid2hwaddr(ddhcp_node_id * node_id) {
+    uint8_t * hwaddr = calloc(6, sizeof(uint8_t));
+    if (!hwaddr) {
+        return NULL;
+    }
+
+    // TODO: memcpy?
+    for (int i = 0; i < 6; ++i) {
+        hwaddr[i] = *node_id[2 + i];
+    }
+
+    return hwaddr;
+}

--- a/types.h
+++ b/types.h
@@ -102,6 +102,7 @@ struct dhcp_lease {
   enum dhcp_lease_state state;
   uint32_t xid;
   time_t lease_end;
+  uint8_t hookclaim;
 };
 typedef struct dhcp_lease dhcp_lease;
 


### PR DESCRIPTION
See https://github.com/freifunk-gluon/ddhcpd/pull/4#discussion_r1103698043

Example hook to work with l3roamd

```sh
#!/bin/sh

# NOTE: we need to prefix with ::ffff: in del_address because of a bug in l3roamd
# add_address is modified for consistency

case "$1" in
	lease)
		echo add_address "::ffff:$2" "$3" | uc /var/run/l3roamd.sock
		;;

	release)
		echo del_address "::ffff:$2" "$3" | uc /var/run/l3roamd.sock
		;;


	claim)
		ip route add "$2" dev local-node proto 158
		;;

	claimrelease)
		ip route del "$2" dev local-node proto 158
		;;
esac
```