### PR TITLE
Use sig_atomic_t for signal handler usage

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@
 #include "tools.h"
 #include "version.h"
 
-volatile int daemon_running = 0;
+static volatile sig_atomic_t daemon_running = 0;
 
 extern int log_level;
 


### PR DESCRIPTION
The C language specifies sig_atomic_t to be used for variable assignment in signal handlers. Let's use it, even though it will be an int in almost all cases anyway.